### PR TITLE
Add fields to Payment

### DIFF
--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -224,9 +224,19 @@ type Payment struct {
 		} `json:"transaction"`
 	} `json:"_links"`
 
+	TransactionHash string `json:"transaction_hash"`
+	SourceAccount   string `json:"source_account"`
+	CreatedAt       string `json:"created_at"`
+
+	// create_account and account_merge field
+	Account string `json:"account"`
+
 	// create_account fields
-	Account         string `json:"account"`
+	Funder          string `json:"funder"`
 	StartingBalance string `json:"starting_balance"`
+
+	// account_merge fields
+	Into string `json:into"`
 
 	// payment/path_payment fields
 	From        string `json:"from"`


### PR DESCRIPTION
These fields are present in the horizon json responses I've seen, but missing from the go deserialization.

They can be found [here](https://github.com/stellar/go/blob/3a84b177d74e14c7c5e0736013bfd299414d0692/services/horizon/internal/resource/operations/main.go#L115) in the horizon service source. It would be nice to use those nicely organized nested types, but that's a bigger change for another time.

I'd like these for the recent payments rpc.